### PR TITLE
fixed conflict when using str as argument of ListBase.parse

### DIFF
--- a/resync/list_base.py
+++ b/resync/list_base.py
@@ -74,11 +74,11 @@ class ListBase(ResourceContainer):
         """
         self.parse(uri=uri)
 
-    def parse(self,uri=None,fh=None,str=None):
+    def parse(self,uri=None,fh=None,str_data=None):
         """Parse a single XML document for this list
 
         Accepts either a uri (uri or default if parameter not specified), 
-        or a filehandle (fh) or a string (str).
+        or a filehandle (fh) or a string (str_data).
 
         Does not handle the case of sitemapindex+sitemaps
         """
@@ -87,8 +87,8 @@ class ListBase(ResourceContainer):
                 fh = URLopener().open(uri)
             except IOError as e:
                 raise Exception("Failed to load sitemap/sitemapindex from %s (%s)" % (uri,str(e)))
-        elif (str is not None):
-            fh=StringIO.StringIO(str)
+        elif (str_data is not None):
+            fh=StringIO.StringIO(str_data)
         if (fh is None):
             raise Exception("Nothing to parse")
         s = self.new_sitemap()

--- a/resync/list_base.py
+++ b/resync/list_base.py
@@ -74,11 +74,11 @@ class ListBase(ResourceContainer):
         """
         self.parse(uri=uri)
 
-    def parse(self,uri=None,fh=None,str_data=None):
+    def parse(self,uri=None,fh=None,str=None):
         """Parse a single XML document for this list
 
         Accepts either a uri (uri or default if parameter not specified), 
-        or a filehandle (fh) or a string (str_data).
+        or a filehandle (fh) or a string (str).
 
         Does not handle the case of sitemapindex+sitemaps
         """
@@ -86,9 +86,10 @@ class ListBase(ResourceContainer):
             try:
                 fh = URLopener().open(uri)
             except IOError as e:
-                raise Exception("Failed to load sitemap/sitemapindex from %s (%s)" % (uri,str(e)))
-        elif (str_data is not None):
-            fh=StringIO.StringIO(str_data)
+                msg = __builtins__.str(e)
+                raise Exception("Failed to load sitemap/sitemapindex from %s (%s)" % (uri, e))
+        elif (str is not None):
+            fh=StringIO.StringIO(str)
         if (fh is None):
             raise Exception("Nothing to parse")
         s = self.new_sitemap()


### PR DESCRIPTION
When I run one of the examples of README I discovered an error in ListBase.parse. This small modification fixes the issue.