### PR TITLE
Enable configuration of timeout and number of retries for resource download attempts

### DIFF
--- a/bin/resync
+++ b/bin/resync
@@ -173,6 +173,12 @@ def main():
     opt.add_option('--eval', '-e', action='store_true',
                    help="output evaluation of source/client synchronization performance... "
                         "be warned, this is very verbose")
+    opt.add_option('--tries', '-t', type=int, action='store', metavar='TRIES',
+                   help="set number of tries to TRIES. The default is to retry 20 times, "
+                        "with the exception of fatal errors like \"connection refused\" "
+                        "or \"not found\" (404), which are not retried.")
+    opt.add_option('--timeout', '-T', type=int, action='store', metavar='SECONDS',
+                   help="set the request timeout for resource downloads to SECONDS seconds")
 
     (args, map) = p.parse_args()
 
@@ -227,6 +233,10 @@ def main():
             c.max_sitemap_entries = args.max_sitemap_entries
         if (args.ignore_failures):
             c.ignore_failures = args.ignore_failures
+        if (args.tries):
+            c.tries = args.tries
+        if (args.timeout):
+            c.timeout = args.timeout
 
         # Links apply to anything that writes sitemaps
         links = parse_links(args.link)

--- a/resync/archives.py
+++ b/resync/archives.py
@@ -9,10 +9,6 @@ Resource Dump Archive, and Change Dump Archive.
 """
 
 import collections
-try:  # python3
-    from urllib.request import URLopener
-except ImportError:  # python2
-    from urllib import URLopener
 
 from .list_base_with_index import ListBaseWithIndex
 from .resource import Resource

--- a/resync/change_list.py
+++ b/resync/change_list.py
@@ -16,10 +16,6 @@ particular resource.
 """
 
 import collections
-try:  # python3
-    from urllib.request import URLopener
-except ImportError:  # python2
-    from urllib import URLopener
 
 from .list_base_with_index import ListBaseWithIndex
 from .resource import Resource, ChangeTypeError

--- a/resync/client.py
+++ b/resync/client.py
@@ -60,6 +60,8 @@ class Client(object):
         self.ignore_failures = False
         self.pretty_xml = True
         self.fake_input = None
+        self.tries = 20
+        self.timeout = None
         # Default file names
         self.status_file = '.resync-client-status.cfg'
         self.default_resource_dump = 'resourcedump.zip'
@@ -496,19 +498,36 @@ class Client(object):
                 (resource.uri, filename))
         else:
             # 1. GET
-            try:
-                r = requests.get(resource.uri, stream=True)
-                with open(filename, 'wb') as fd:
-                    for chunk in r.iter_content(chunk_size=1024):
-                        fd.write(chunk)
-                num_updated += 1
-            except IOError as e:
-                msg = "Failed to GET %s -- %s" % (resource.uri, str(e))
-                if (self.ignore_failures):
-                    self.logger.warning(msg)
-                    return(num_updated)
-                else:
-                    raise ClientFatalError(msg)
+            for try_i in range(1, self.tries + 1):
+                try:
+                    r = requests.get(resource.uri, timeout=self.timeout, stream=True)
+                    # Fail on 4xx or 5xx
+                    r.raise_for_status()
+                    with open(filename, 'wb') as fd:
+                        for chunk in r.iter_content(chunk_size=1024):
+                            fd.write(chunk)
+                    num_updated += 1
+                    break
+                except requests.Timeout as e:
+                    if try_i < self.tries:
+                        msg = 'Download timed out, retrying...'
+                        self.logger.info(msg)
+                        # Continue loop
+                    else:
+                        # No more tries left, so fail
+                        msg = "Failed to GET %s after %s tries -- %s" % (resource.uri, self.tries, str(e))
+                        if (self.ignore_failures):
+                            self.logger.warning(msg)
+                            return(num_updated)
+                        else:
+                            raise ClientFatalError(msg)
+                except (requests.RequestException, IOError) as e:
+                    msg = "Failed to GET %s -- %s" % (resource.uri, str(e))
+                    if (self.ignore_failures):
+                        self.logger.warning(msg)
+                        return(num_updated)
+                    else:
+                        raise ClientFatalError(msg)
             # 2. set timestamp if we have one
             if (resource.timestamp is not None):
                 unixtime = int(resource.timestamp)  # no fractional

--- a/resync/client.py
+++ b/resync/client.py
@@ -2,10 +2,8 @@
 
 import sys
 try:  # python3
-    from urllib.request import urlretrieve
     from urllib.parse import urlsplit, urlunsplit, urljoin
 except ImportError:  # python2
-    from urllib import urlretrieve
     from urlparse import urlsplit, urlunsplit, urljoin
 import os.path
 import datetime
@@ -499,7 +497,10 @@ class Client(object):
         else:
             # 1. GET
             try:
-                urlretrieve(resource.uri, filename)
+                r = requests.get(resource.uri, stream=True)
+                with open(filename, 'wb') as fd:
+                    for chunk in r.iter_content(chunk_size=1024):
+                        fd.write(chunk)
                 num_updated += 1
             except IOError as e:
                 msg = "Failed to GET %s -- %s" % (resource.uri, str(e))

--- a/resync/resource_list.py
+++ b/resync/resource_list.py
@@ -22,10 +22,6 @@ import os
 from datetime import datetime
 import re
 import sys
-try:  # python3
-    from urllib.request import URLopener
-except ImportError:  # python2
-    from urllib import URLopener
 
 from .list_base_with_index import ListBaseWithIndex
 from .sitemap import Sitemap

--- a/resync/resource_list_builder.py
+++ b/resync/resource_list_builder.py
@@ -6,10 +6,6 @@ import re
 import sys
 import time
 import logging
-try:  # python3
-    from urllib.request import URLopener
-except ImportError:  # python2
-    from urllib import URLopener
 from defusedxml.ElementTree import parse
 
 from .hashes import Hashes

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -109,7 +109,7 @@ class TestClient(TestCase):
             # get from file uri that does not exist
             resource = Resource(uri='http://localhost:9999/i_do_not_exist')
             self.assertRaises(ClientFatalError,
-                            c.update_resource, resource, filename)
+                              c.update_resource, resource, filename)
             # get from file uri that does not exist but with c.ignore_failures to
             # log
             resource = Resource(uri='http://localhost:9999/i_do_not_exist')

--- a/tests/testdata/client/dir1/resourcelist.xml
+++ b/tests/testdata/client/dir1/resourcelist.xml
@@ -2,16 +2,16 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:rs="http://www.openarchives.org/rs/terms/">
   <rs:ln rel="up"
-         href="file:tests/testdata/client/dir1/caps1.xml"/>
+         href="http://localhost:9999/dir1/caps1.xml"/>
   <rs:md capability="resourcelist"
          modified="2013-01-03T15:00:00Z"/>
   <url>
-      <loc>file:tests/testdata/client/dir1/resource1</loc>
+      <loc>http://localhost:9999/dir1/resource1</loc>
   </url>
   <url>
-      <loc>file:tests/testdata/client/dir1/resource2</loc>
+      <loc>http://localhost:9999/dir1/resource2</loc>
   </url>
   <url>
-      <loc>file:tests/testdata/client/dir1/resource3</loc>
+      <loc>http://localhost:9999/dir1/resource3</loc>
   </url>
 </urlset>


### PR DESCRIPTION
The new CLI flags `-t` and `-T` have the same semantics as in `wget`.

Fixes #34 